### PR TITLE
opt(Or): Introduce FastParOr to make FastOr concurrent

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -85,21 +85,7 @@ func BenchmarkSetRoaring(b *testing.B) {
 	}
 }
 
-type uint64Heap []uint64
-
-func (u uint64Heap) Len() int            { return len(u) }
-func (u uint64Heap) Less(i, j int) bool  { return u[i] < u[j] }
-func (u uint64Heap) Swap(i, j int)       { u[i], u[j] = u[j], u[i] }
-func (u *uint64Heap) Push(x interface{}) { *u = append(*u, x.(uint64)) }
-func (u *uint64Heap) Pop() interface{} {
-	old := *u
-	n := len(old)
-	x := old[n-1]
-	*u = old[0 : n-1]
-	return x
-}
-
-func BenchmarkMerge11K(b *testing.B) {
+func BenchmarkMerge10K(b *testing.B) {
 	var bitmaps []*Bitmap
 	for i := 0; i < 10000; i++ {
 		bm := NewBitmap()

--- a/bitmap.go
+++ b/bitmap.go
@@ -832,7 +832,11 @@ func FastAnd(bitmaps ...*Bitmap) *Bitmap {
 // faster than operating at a container level, because we can't operate on array
 // containers belonging to the same Bitmap concurrently because array containers
 // can expand, leaving no clear boundaries.
+//
 // If FastParOr is called with numGo=1, it just calls FastOr.
+//
+// Experiments with numGo=4 shows that FastParOr would be 2x the speed of
+// FastOr, but 4x the memory usage, even under 50% CPU usage. So, use wisely.
 func FastParOr(numGo int, bitmaps ...*Bitmap) *Bitmap {
 	if numGo == 1 {
 		return FastOr(bitmaps...)

--- a/bitmap.go
+++ b/bitmap.go
@@ -435,7 +435,7 @@ func (ra *Bitmap) String() string {
 		card += int(c[indexCardinality])
 
 		b.WriteString(fmt.Sprintf(
-			"[%d] Key: %#x. Offset: %d. Size: %d. Type: %d. Card: %d. Uint16/Uid: %.2f\n",
+			"[%03d] Key: %#8x. Offset: %7d. Size: %4d. Type: %d. Card: %6d. Uint16/Uid: %.2f\n",
 			i, k, v, sz, c[indexType], c[indexCardinality],
 			float64(sz)/float64(c[indexCardinality])))
 	}

--- a/real_data_test.go
+++ b/real_data_test.go
@@ -139,7 +139,12 @@ func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) int) 
 
 func BenchmarkRealDataFastOr(b *testing.B) {
 	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) int {
-		return FastParOr(8, bitmaps...).GetCardinality()
+		return FastOr(bitmaps...).GetCardinality()
+	})
+}
+func BenchmarkRealDataFastParOr(b *testing.B) {
+	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) int {
+		return FastParOr(4, bitmaps...).GetCardinality()
 	})
 }
 

--- a/real_data_test.go
+++ b/real_data_test.go
@@ -118,7 +118,7 @@ func processZipFile(f *zip.File) ([]uint64, error) {
 
 func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) int) {
 	for _, dataset := range realDatasets {
-		once := true
+		once := false
 		b.Run(dataset, func(b *testing.B) {
 			bitmaps, err := retrieveRealDataBitmaps(dataset, true)
 			if err != nil {
@@ -139,7 +139,7 @@ func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) int) 
 
 func BenchmarkRealDataFastOr(b *testing.B) {
 	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) int {
-		return FastOr(1, bitmaps...).GetCardinality()
+		return FastParOr(8, bitmaps...).GetCardinality()
 	})
 }
 
@@ -179,7 +179,7 @@ func TestOrRealData(t *testing.T) {
 		}
 
 		// Check that union operation is correct.
-		res := FastOr(1, bitmaps...)
+		res := FastOr(bitmaps...)
 		c := res.GetCardinality()
 
 		t.Logf("Result: %s\n", res)

--- a/real_data_test.go
+++ b/real_data_test.go
@@ -139,7 +139,7 @@ func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) int) 
 
 func BenchmarkRealDataFastOr(b *testing.B) {
 	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) int {
-		return FastOr(bitmaps...).GetCardinality()
+		return FastOr(1, bitmaps...).GetCardinality()
 	})
 }
 
@@ -179,7 +179,7 @@ func TestOrRealData(t *testing.T) {
 		}
 
 		// Check that union operation is correct.
-		res := FastOr(bitmaps...)
+		res := FastOr(1, bitmaps...)
 		c := res.GetCardinality()
 
 		t.Logf("Result: %s\n", res)

--- a/real_data_test.go
+++ b/real_data_test.go
@@ -118,14 +118,17 @@ func processZipFile(f *zip.File) ([]uint64, error) {
 
 func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) int) {
 	for _, dataset := range realDatasets {
+		once := true
 		b.Run(dataset, func(b *testing.B) {
 			bitmaps, err := retrieveRealDataBitmaps(dataset, true)
 			if err != nil {
 				b.Fatal(err)
 			}
-			c := aggregator(bitmaps)
-			_ = c
-			// b.Logf("Got cardinality: %d\n", c)
+			if once {
+				c := aggregator(bitmaps)
+				b.Logf("Dataset: %s Got cardinality: %d\n", dataset, c)
+				once = false
+			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				aggregator(bitmaps)

--- a/setutil.go
+++ b/setutil.go
@@ -13,6 +13,12 @@ func min(a, b int) int {
 	}
 	return b
 }
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
 
 func equal(a, b []uint16) bool {
 	if len(a) != len(b) {

--- a/utils.go
+++ b/utils.go
@@ -38,6 +38,19 @@ func check2(_ interface{}, err error) {
 	check(err)
 }
 
+func min16(a, b uint16) uint16 {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max16(a, b uint16) uint16 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func toByteSlice(b []uint16) []byte {
 	// reference: https://go101.org/article/unsafe.html
 	var bs []byte


### PR DESCRIPTION
Benchmarks with 50% CPU load show that FastParOr is 2x faster than FastOr, and 4x the memory usage.

```
name                                      old time/op    new time/op    delta
RealDataFastOr/census-income_srt-32         1.73ms ±14%    0.91ms ± 1%   -47.73%  (p=0.008 n=5+5)
RealDataFastOr/census-income-32             1.85ms ±14%    0.98ms ± 1%   -47.37%  (p=0.008 n=5+5)
RealDataFastOr/census1881_srt-32            3.67ms ± 5%    2.84ms ± 1%   -22.76%  (p=0.008 n=5+5)
RealDataFastOr/census1881-32                3.19ms ± 3%    4.98ms ± 1%   +56.24%  (p=0.008 n=5+5)
RealDataFastOr/dimension_003-32             14.5ms ±10%     6.4ms ± 1%   -55.94%  (p=0.008 n=5+5)
RealDataFastOr/dimension_008-32             4.57ms ± 5%    1.97ms ± 1%   -56.94%  (p=0.008 n=5+5)
RealDataFastOr/dimension_033-32             4.14ms ± 6%    5.06ms ± 2%   +22.20%  (p=0.008 n=5+5)
RealDataFastOr/uscensus2000-32               860µs ± 4%    1228µs ± 2%   +42.77%  (p=0.008 n=5+5)
RealDataFastOr/weather_sept_85_srt-32       4.34ms ±11%    2.43ms ± 1%   -43.99%  (p=0.008 n=5+5)
RealDataFastOr/weather_sept_85-32           6.96ms ±10%    3.32ms ± 1%   -52.26%  (p=0.008 n=5+5)
RealDataFastOr/wikileaks-noquotes_srt-32    1.39ms ± 5%    1.29ms ± 1%    -7.23%  (p=0.008 n=5+5)
RealDataFastOr/wikileaks-noquotes-32        1.27ms ± 3%    2.62ms ± 1%  +106.27%  (p=0.008 n=5+5)

name                                      old alloc/op   new alloc/op   delta
RealDataFastOr/census-income_srt-32         69.6kB ± 0%   348.3kB ± 0%  +400.18%  (p=0.008 n=5+5)
RealDataFastOr/census-income-32             69.6kB ± 0%   348.3kB ± 0%  +400.16%  (p=0.008 n=5+5)
RealDataFastOr/census1881_srt-32            1.48MB ± 0%    4.12MB ± 0%  +177.76%  (p=0.008 n=5+5)
RealDataFastOr/census1881-32                1.48MB ± 0%    7.41MB ± 0%  +400.01%  (p=0.008 n=5+5)
RealDataFastOr/dimension_003-32             1.28MB ± 0%    5.74MB ± 0%  +349.78%  (p=0.008 n=5+5)
RealDataFastOr/dimension_008-32              162kB ± 0%     470kB ± 0%  +190.68%  (p=0.008 n=5+5)
RealDataFastOr/dimension_033-32             1.28MB ± 0%    5.11MB ± 0%  +300.59%  (p=0.008 n=5+5)
RealDataFastOr/uscensus2000-32               240kB ± 0%     927kB ± 0%  +286.56%  (p=0.008 n=5+5)
RealDataFastOr/weather_sept_85_srt-32        293kB ± 0%    1463kB ± 0%  +400.04%  (p=0.008 n=5+5)
RealDataFastOr/weather_sept_85-32            292kB ± 0%    1463kB ± 0%  +400.04%  (p=0.008 n=5+5)
RealDataFastOr/wikileaks-noquotes_srt-32     587kB ± 0%    1758kB ± 0%  +199.21%  (p=0.008 n=5+5)
RealDataFastOr/wikileaks-noquotes-32         587kB ± 0%    2362kB ± 0%  +302.08%  (p=0.008 n=5+5)

name                                      old allocs/op  new allocs/op  delta
RealDataFastOr/census-income_srt-32           9.00 ± 0%     50.00 ± 0%  +455.56%  (p=0.008 n=5+5)
RealDataFastOr/census-income-32               9.00 ± 0%     50.00 ± 0%  +455.56%  (p=0.008 n=5+5)
RealDataFastOr/census1881_srt-32              27.0 ± 0%     135.0 ± 0%  +400.00%  (p=0.008 n=5+5)
RealDataFastOr/census1881-32                  27.0 ± 0%     141.4 ± 0%  +423.70%  (p=0.008 n=5+5)
RealDataFastOr/dimension_003-32               25.6 ± 2%     124.6 ± 0%  +386.72%  (p=0.008 n=5+5)
RealDataFastOr/dimension_008-32               22.6 ± 3%     103.6 ± 1%  +358.41%  (p=0.008 n=5+5)
RealDataFastOr/dimension_033-32               26.0 ± 0%     130.0 ± 0%  +400.00%  (p=0.016 n=5+4)
RealDataFastOr/uscensus2000-32                54.6 ± 1%     230.0 ± 0%  +321.25%  (p=0.016 n=5+4)
RealDataFastOr/weather_sept_85_srt-32         14.0 ± 0%      79.0 ± 0%  +464.29%  (p=0.008 n=5+5)
RealDataFastOr/weather_sept_85-32             14.0 ± 0%      79.0 ± 0%  +464.29%  (p=0.008 n=5+5)
RealDataFastOr/wikileaks-noquotes_srt-32      16.0 ± 0%      82.0 ± 0%  +412.50%  (p=0.008 n=5+5)
RealDataFastOr/wikileaks-noquotes-32          16.0 ± 0%      84.0 ± 0%  +425.00%  (p=0.016 n=5+4)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/5)
<!-- Reviewable:end -->
