### PR TITLE
Add Iterate for allocation-free iteration

### DIFF
--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -564,6 +564,41 @@ func TestClone(t *testing.T) {
 	require.Equal(t, a.ToArray(), b.ToArray())
 }
 
+func TestIterate(t *testing.T) {
+	a := NewBitmap()
+	N := 100
+
+	var values []uint64
+	for i := 0; i < N; i++ {
+		value := uint64(rand.Int63n(math.MaxInt64))
+		values = append(values, value)
+		a.Set(value)
+	}
+
+	var iterated []uint64
+	a.Iterate(func(x uint64) bool {
+		iterated = append(iterated, x)
+		return true
+	})
+	require.ElementsMatch(t, values, iterated)
+}
+
+func TestIterateHalt(t *testing.T) {
+	a := NewBitmap()
+	N := 100
+
+	for i := 0; i < N; i++ {
+		a.Set(uint64(rand.Int63n(math.MaxInt64)))
+	}
+
+	var iterated []uint64
+	a.Iterate(func(x uint64) bool {
+		iterated = append(iterated, x)
+		return false
+	})
+	require.Len(t, iterated, 1)
+}
+
 func TestContainerFull(t *testing.T) {
 	c := make([]uint16, maxContainerSize)
 	b := bitmap(c)

--- a/container.go
+++ b/container.go
@@ -530,17 +530,26 @@ func (b bitmap) orArray(other array, buf []uint16, runMode int) []uint16 {
 
 func (b bitmap) all() []uint16 {
 	var res []uint16
+	b.iterate(func(x uint16) bool {
+		res = append(res, x)
+		return true
+	})
+	return res
+}
+
+func (b bitmap) iterate(cb func(x uint16) bool) {
 	data := b[startIdx:]
 	for idx := uint16(0); idx < uint16(len(data)); idx++ {
 		x := data[idx]
 		// TODO: This could potentially be optimized.
 		for pos := uint16(0); pos < 16; pos++ {
 			if x&bitmapMask[pos] > 0 {
-				res = append(res, (idx<<4)|pos)
+				if !cb((idx << 4) | pos) {
+					return
+				}
 			}
 		}
 	}
-	return res
 }
 
 //TODO: It can be optimized.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -117,10 +118,31 @@ func BenchmarkIterator(b *testing.B) {
 		bm.Set(uint64(i))
 	}
 	b.ResetTimer()
-	it := bm.NewIterator()
+	b.ReportAllocs()
+
+	var x uint64
 	for i := 0; i < b.N; i++ {
+		it := bm.NewIterator()
 		for it.HasNext() {
-			it.Next()
+			x = it.Next()
 		}
+	}
+	runtime.KeepAlive(x)
+}
+
+func BenchmarkIterate(b *testing.B) {
+	bm := NewBitmap()
+
+	N := int(1e5)
+	for i := 0; i < N; i++ {
+		bm.Set(uint64(i))
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		bm.Iterate(func(x uint64) bool {
+			return true
+		})
 	}
 }


### PR DESCRIPTION
This commit adds the `Iterate` method to the bitmap that accepts a callback function for each value in the bitmap.  If the callback function returns false, the iteration is halted

This pattern allows for iterating the bitmap with 0 allocations:

```
name        time/op
Iterator-8  1.35ms ± 4%
Iterate-8    374µs ± 5%

name        alloc/op
Iterator-8  4.65MB ± 0%
Iterate-8    0.00B

name        allocs/op
Iterator-8    30.0 ± 0%
Iterate-8     0.00
```

This commit also fixes the existing `BenchmarkIterate` function to correctly benchmark the iterator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/10)
<!-- Reviewable:end -->
