### PR TITLE
Add ToBufferWithCopy

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -72,6 +72,12 @@ func (ra *Bitmap) ToBuffer() []byte {
 	return toByteSlice(ra.data)
 }
 
+func (ra *Bitmap) ToBufferWithCopy() []byte {
+	buf := make([]uint16, len(ra.data))
+	copy(buf, ra.data)
+	return toByteSlice(buf)
+}
+
 func NewBitmap() *Bitmap {
 	return NewBitmapWith(2)
 }


### PR DESCRIPTION
`ToBufferWithCopy` generates a buffer for the bitmap from the copy of the original data buffer. This enables the bitmap to be usable even after a call to `ToBufferWithCopy`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/11)
<!-- Reviewable:end -->
