### PR TITLE
Maximum() reads from the last container

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -610,13 +610,29 @@ func (ra *Bitmap) extreme(dir int) uint64 {
 	if N == 0 {
 		return 0
 	}
-	n := 0
-	if dir == rev {
-		n = ra.keys.numKeys() - 1
+
+	var k uint64
+	var c []uint16
+
+	if dir == fwd {
+		for i := 0; i < N; i++ {
+			offset := ra.keys.val(i)
+			c = ra.getContainer(offset)
+			if getCardinality(c) > 0 {
+				k = ra.keys.key(i)
+				break
+			}
+		}
+	} else {
+		for i := N - 1; i >= 0; i-- {
+			offset := ra.keys.val(i)
+			c = ra.getContainer(offset)
+			if getCardinality(c) > 0 {
+				k = ra.keys.key(i)
+				break
+			}
+		}
 	}
-	k := ra.keys.key(n)
-	offset := ra.keys.val(n)
-	c := ra.getContainer(offset)
 
 	switch c[indexType] {
 	case typeArray:

--- a/bitmap.go
+++ b/bitmap.go
@@ -610,8 +610,12 @@ func (ra *Bitmap) extreme(dir int) uint64 {
 	if N == 0 {
 		return 0
 	}
-	k := ra.keys.key(0)
-	offset := ra.keys.val(0)
+	n := 0
+	if dir == rev {
+		n = ra.keys.numKeys() - 1
+	}
+	k := ra.keys.key(n)
+	offset := ra.keys.val(n)
 	c := ra.getContainer(offset)
 
 	switch c[indexType] {

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -601,4 +601,16 @@ func TestExtremes(t *testing.T) {
 	a.Set(100000)
 	require.Equal(t, uint64(1), a.Minimum())
 	require.Equal(t, uint64(100000), a.Maximum())
+
+	a.Remove(100000)
+	require.Equal(t, uint64(1), a.Minimum())
+	require.Equal(t, uint64(1), a.Maximum())
+
+	a.Remove(1)
+	require.Equal(t, uint64(0), a.Minimum())
+	require.Equal(t, uint64(0), a.Maximum())
+
+	a.Set(100000)
+	require.Equal(t, uint64(100000), a.Minimum())
+	require.Equal(t, uint64(100000), a.Maximum())
 }

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -588,3 +588,17 @@ func TestContainerFull(t *testing.T) {
 	setCardinality(b, b.cardinality())
 	require.Equal(t, maxCardinality, getCardinality(b))
 }
+
+func TestExtremes(t *testing.T) {
+	a := NewBitmap()
+	require.Equal(t, uint64(0), a.Minimum())
+	require.Equal(t, uint64(0), a.Maximum())
+
+	a.Set(1)
+	require.Equal(t, uint64(1), a.Minimum())
+	require.Equal(t, uint64(1), a.Maximum())
+
+	a.Set(100000)
+	require.Equal(t, uint64(1), a.Minimum())
+	require.Equal(t, uint64(100000), a.Maximum())
+}


### PR DESCRIPTION
Please double check if this is the right fix as I didn't know anything about Roaring Bitmaps 10 minutes ago ;-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/12)
<!-- Reviewable:end -->
