### PR TITLE
fix(FastOr): Don't create containers for zero cardinality containers

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -979,7 +979,7 @@ func FastOr(bitmaps ...*Bitmap) *Bitmap {
 	// without having to move a lot of memory.
 	for key, card := range containers {
 		// Ensure this condition exactly maps up with above.
-		if card < 4096 {
+		if card < 4096 && card > 0 {
 			if card < minContainerSize {
 				card = minContainerSize
 			}


### PR DESCRIPTION
We should only create containers that can have a non-zero number of elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/16)
<!-- Reviewable:end -->
