### PR TITLE
Cleanup the bitmap after intersection and remove range using scoot left

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -1003,8 +1003,10 @@ func FastOr(bitmaps ...*Bitmap) *Bitmap {
 	// First create the keys. We do this as a separate step, because keys are
 	// the left most portion of the data array. Adding space there requires
 	// moving a lot of pieces.
-	for key := range containers {
-		dst.setKey(key, 0)
+	for key, card := range containers {
+		if card > 0 {
+			dst.setKey(key, 0)
+		}
 	}
 
 	// Then create the bitmap containers.

--- a/bitmap.go
+++ b/bitmap.go
@@ -190,7 +190,8 @@ func (ra *Bitmap) scootLeft(offset uint64, size uint64) {
 }
 
 func (ra *Bitmap) removeKey(idx int) {
-	off := uint64(4 * (indexNodeStart + 2*idx))
+	off := uint64(4 * keyOffset(idx))
+	// remove 8 u16s, which corresponds to a key and value (two u64s)
 	ra.scootLeft(off, 8)
 	ra.keys.updateOffsets(off, 8, false)
 	ra.keys.setNumKeys(ra.keys.numKeys() - 1)

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -636,3 +636,23 @@ func TestExtremes(t *testing.T) {
 	require.Equal(t, uint64(100000), a.Minimum())
 	require.Equal(t, uint64(100000), a.Maximum())
 }
+
+func TestCleanup(t *testing.T) {
+	a := NewBitmap()
+	n := int(1e6)
+	for i := 0; i < n; i++ {
+		a.Set(uint64(i))
+	}
+	for i := 65536; i < n; i++ {
+		a.Remove(uint64(i))
+	}
+
+	a.Cleanup()
+	for i := 0; i < 65535; i++ {
+		require.Truef(t, a.Contains(uint64(i)), "idx: %d", i)
+	}
+	for i := 65536; i < n; i++ {
+		require.Falsef(t, a.Contains(uint64(i)), "idx: %d", i)
+	}
+
+}

--- a/container.go
+++ b/container.go
@@ -636,11 +636,11 @@ func (b bitmap) cardinality() int {
 	return num
 }
 
+var zeroContainer = make([]uint16, maxContainerSize)
+
 func (b bitmap) zeroOut() {
 	setCardinality(b, 0)
-	for i := range b[startIdx:] {
-		b[startIdx+uint16(i)] = 0
-	}
+	copy(b[startIdx:], zeroContainer[startIdx:])
 }
 
 var (

--- a/container.go
+++ b/container.go
@@ -437,7 +437,7 @@ func (b bitmap) removeRange(lo, hi uint16) {
 func (b bitmap) has(x uint16) bool {
 	idx := x >> 4
 	pos := x & 0xF
-
+	// fmt.Println(b[startIdx+idx], bitmapMask[pos])
 	has := b[startIdx+idx] & bitmapMask[pos]
 	return has > 0
 }

--- a/container.go
+++ b/container.go
@@ -437,7 +437,6 @@ func (b bitmap) removeRange(lo, hi uint16) {
 func (b bitmap) has(x uint16) bool {
 	idx := x >> 4
 	pos := x & 0xF
-	// fmt.Println(b[startIdx+idx], bitmapMask[pos])
 	has := b[startIdx+idx] & bitmapMask[pos]
 	return has > 0
 }

--- a/keys.go
+++ b/keys.go
@@ -168,18 +168,14 @@ func (n node) set(k, v uint64) bool {
 	// panic("shouldn't reach here")
 }
 
-func (n node) updateOffsetsLeft(beyond, by uint64) {
+func (n node) updateOffsets(beyond, by uint64, add bool) {
 	for i := 0; i < n.numKeys(); i++ {
 		if offset := n.val(i); offset > beyond {
-			n.setAt(valOffset(i), offset-by)
-		}
-	}
-}
-
-func (n node) updateOffsets(beyond, by uint64) {
-	for i := 0; i < n.numKeys(); i++ {
-		if offset := n.val(i); offset > beyond {
-			n.setAt(valOffset(i), offset+by)
+			if add {
+				n.setAt(valOffset(i), offset+by)
+			} else {
+				n.setAt(valOffset(i), offset-by)
+			}
 		}
 	}
 }

--- a/keys.go
+++ b/keys.go
@@ -168,8 +168,16 @@ func (n node) set(k, v uint64) bool {
 	// panic("shouldn't reach here")
 }
 
+func (n node) updateOffsetsLeft(beyond, by uint64) {
+	for i := 0; i < n.numKeys(); i++ {
+		if offset := n.val(i); offset > beyond {
+			n.setAt(valOffset(i), offset-by)
+		}
+	}
+}
+
 func (n node) updateOffsets(beyond, by uint64) {
-	for i := 0; i < n.maxKeys(); i++ {
+	for i := 0; i < n.numKeys(); i++ {
 		if offset := n.val(i); offset > beyond {
 			n.setAt(valOffset(i), offset+by)
 		}

--- a/keys.go
+++ b/keys.go
@@ -174,6 +174,7 @@ func (n node) updateOffsets(beyond, by uint64, add bool) {
 			if add {
 				n.setAt(valOffset(i), offset+by)
 			} else {
+				assert(offset >= by)
 				n.setAt(valOffset(i), offset-by)
 			}
 		}


### PR DESCRIPTION
We observed that the uncleaned bitmaps grow so big that it affects performance and memory. 
It is necessary to clean the bitmap i.e. remove containers with zero cardinality after operations
like intersection and remove range. It is being done in this PR using scoot left.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/18)
<!-- Reviewable:end -->
