### PR TITLE
fix(AndNot): Fix the logic of AndNot

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -837,11 +837,11 @@ func (ra *Bitmap) AndNot(bm *Bitmap) {
 
 			ai++
 			bi++
+			continue
 		}
 		if ak > bk {
 			bi++
-		}
-		if ak < bk {
+		} else {
 			ai++
 		}
 	}

--- a/bitmap.go
+++ b/bitmap.go
@@ -833,32 +833,16 @@ func (ra *Bitmap) AndNot(bm *Bitmap) {
 			offset := a.newContainer(uint16(len(c)))
 			copy(a.data[offset:], c)
 			a.setKey(ak, offset)
-			bi++
-		} else if ak > bk {
-			// ak > bk
-			// need to add this b container to a
-			bk := b.keys.key(bi)
-			off := b.keys.val(bi)
-			bc := b.getContainer(off)
 
-			offset := a.newContainer(uint16(len(bc)))
-			copy(a.data[offset:], bc)
-			a.setKey(bk, offset)
+			ai++
 			bi++
 		}
-		ai++
-	}
-
-	// pick up all the keys left in b.
-	for bi < b.keys.numKeys() {
-		bk := b.keys.key(bi)
-		off := b.keys.val(bi)
-		bc := b.getContainer(off)
-
-		offset := a.newContainer(uint16(len(bc)))
-		copy(a.data[offset:], bc)
-		a.setKey(bk, offset)
-		bi++
+		if ak > bk {
+			bi++
+		}
+		if ak < bk {
+			ai++
+		}
 	}
 }
 

--- a/bitmap.go
+++ b/bitmap.go
@@ -829,7 +829,6 @@ func And(a, b *Bitmap) *Bitmap {
 	return res
 }
 
-// TODO: Do the operations in-place, it will avoid memory moves.
 func (ra *Bitmap) AndNot(bm *Bitmap) {
 	if bm == nil {
 		return
@@ -848,9 +847,8 @@ func (ra *Bitmap) AndNot(bm *Bitmap) {
 			off = b.keys.val(bi)
 			bc := b.getContainer(off)
 
-			// do the intersection
+			// TODO: See if we can do containerAndNot operation in-place.
 			c := containerAndNot(ac, bc, buf)
-
 			// create a new container and update the key offset to this container.
 			offset := a.newContainer(uint16(len(c)))
 			copy(a.data[offset:], c)

--- a/bitmap.go
+++ b/bitmap.go
@@ -808,6 +808,7 @@ func And(a, b *Bitmap) *Bitmap {
 	return res
 }
 
+// TODO: Do the operations in-place, it will avoid memory moves.
 func (ra *Bitmap) AndNot(bm *Bitmap) {
 	if bm == nil {
 		return

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -421,15 +421,34 @@ func TestAndNot(t *testing.T) {
 	a.AndNot(b)
 	require.Equal(t, N/2, a.GetCardinality())
 
-	// Test for case when only array container will be generated.
+	// Test for case when array container will be generated.
 	a = NewBitmap()
 	b = NewBitmap()
 
-	a.SetMany([]uint64{22, 40, 45, 56})
-	b.SetMany([]uint64{7, 8, 9, 14, 15, 16, 17, 19, 20, 21, 22, 29, 30, 31, 63, 64})
+	a.SetMany([]uint64{1, 2, 3, 4})
+	b.SetMany([]uint64{3, 4, 5, 6})
 
 	a.AndNot(b)
-	require.Equal(t, []uint64{40, 45, 56}, a.ToArray())
+	require.Equal(t, []uint64{1, 2}, a.ToArray())
+
+	// Test for case when bitmap container will be generated.
+	a = NewBitmap()
+	b = NewBitmap()
+	for i := 0; i < 10000; i++ {
+		a.Set(uint64(i))
+		if i < 7000 {
+			b.Set(uint64(i))
+		}
+	}
+	a.AndNot(b)
+	require.Equal(t, 3000, a.GetCardinality())
+	for i := 0; i < 10000; i++ {
+		if i < 7000 {
+			require.False(t, a.Contains(uint64(i)))
+		} else {
+			require.True(t, a.Contains(uint64(i)))
+		}
+	}
 }
 
 func TestOr(t *testing.T) {

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -404,19 +404,26 @@ func TestAndNot(t *testing.T) {
 
 	N := int(1e7)
 	for i := 0; i < N; i++ {
+		a.Set(uint64(i))
 		if i < N/2 {
-			a.Set(uint64(i))
-		} else {
 			b.Set(uint64(i))
 		}
 	}
-	require.Equal(t, N/2, a.GetCardinality())
+	require.Equal(t, N, a.GetCardinality())
 	require.Equal(t, N/2, b.GetCardinality())
 
 	a.AndNot(b)
-	require.Equal(t, N, a.GetCardinality())
-	a.AndNot(b)
 	require.Equal(t, N/2, a.GetCardinality())
+
+	// Test for case when only array container will be generated.
+	a = NewBitmap()
+	b = NewBitmap()
+
+	a.SetMany([]uint64{22, 40, 45, 56})
+	b.SetMany([]uint64{7, 8, 9, 14, 15, 16, 17, 19, 20, 21, 22, 29, 30, 31, 63, 64})
+
+	a.AndNot(b)
+	require.Equal(t, []uint64{40, 45, 56}, a.ToArray())
 }
 
 func TestOr(t *testing.T) {

--- a/container.go
+++ b/container.go
@@ -233,6 +233,7 @@ func (c array) andArray(other array) []uint16 {
 	return out
 }
 
+// TODO: We can do this operation in-place on the src array.
 func (c array) andNotArray(other array, buf []uint16) []uint16 {
 	max := getCardinality(c)
 	out := make([]uint16, int(startIdx)+max+1)


### PR DESCRIPTION
There was an issue in the logic of AndNot. The difference was computed
from both side, i.e.  `a.AndNot(b)` used to result in all the elements that are not
common to both `a` and `b`. It should rather only remove the elements from `a`
which are also present in `b`. This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/sroar/24)
<!-- Reviewable:end -->
