### PR TITLE
Fix maximum() for bitmap container

### DIFF
--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -711,6 +711,14 @@ func TestExtremes(t *testing.T) {
 	a.Set(100000)
 	require.Equal(t, uint64(100000), a.Minimum())
 	require.Equal(t, uint64(100000), a.Maximum())
+
+	a.Remove(100000)
+	a = NewBitmap()
+	for i := 0; i <= maxContainerSize; i++ {
+		a.Set(uint64(i))
+	}
+	require.Equal(t, uint64(0), a.Minimum())
+	require.Equal(t, uint64(maxContainerSize), a.Maximum())
 }
 
 func TestCleanup(t *testing.T) {

--- a/container.go
+++ b/container.go
@@ -645,7 +645,7 @@ func (b bitmap) maximum() uint16 {
 		if tz == 16 {
 			continue
 		}
-		return uint16(16*i + 15 - tz)
+		return uint16(16*(i - int(startIdx)) + 15 - tz)
 	}
 	panic("We shouldn't reach here")
 }


### PR DESCRIPTION
While looking at sroaring, I got an unexpected result from the Maximum method when used on a bitmap container. The existing tests only cover the array container implementation and the test below fails:

```
a := NewBitmap()
for i := 0; i <= maxContainerSize; i++ {
  a.Set(uint64(i))
}
require.Equal(t, uint64(0), a.Minimum())
require.Equal(t, uint64(maxContainerSize), a.Maximum())
```

I located the bug to `func (b bitmap) maximum() uint16` that didn't account for the reverse index position being startIndex and not zero.

A test exposing the bug and a fix is included.
